### PR TITLE
Updating to v0.6.0. Adding symlink so that Go binary works with musl libc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine
 MAINTAINER Rob Haswell <rob@cloudfindhq.com>
 
-ENV KOMPOSE_VERSION=v0.1.2
+ENV KOMPOSE_VERSION=v0.6.0
 
-RUN apk add --no-cache curl
-RUN curl -L https://github.com/kubernetes-incubator/kompose/releases/download/${KOMPOSE_VERSION}/kompose_linux-amd64.tar.gz | tar zxO kompose_linux-amd64/kompose > /usr/local/bin/kompose
-RUN chmod +x /usr/local/bin/kompose
+RUN apk update && apk add --no-cache curl \
+ && curl -L https://github.com/kubernetes-incubator/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64.tar.gz | tar zxO kompose-linux-amd64 > /usr/local/bin/kompose \
+ && chmod +x /usr/local/bin/kompose \
+ && adduser -S kompose \
+ && apk del curl
 
-RUN adduser -S kompose
 USER kompose
-
 CMD kompose

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apk update && apk add --no-cache curl \
  && curl -L https://github.com/kubernetes-incubator/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64.tar.gz | tar zxO kompose-linux-amd64 > /usr/local/bin/kompose \
  && chmod +x /usr/local/bin/kompose \
  && adduser -S kompose \
- && apk del curl
+ && apk del curl \
+ && mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+# ^^^ Last line is so that the GO binary expecting glibc (rather than musllibc used by alpine) will work properly.
 
 USER kompose
 CMD kompose


### PR DESCRIPTION
The first commit is explained in the commit message.

Found the resolution for the second commit [here](http://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker#35613430)